### PR TITLE
fix: fullscreen issue

### DIFF
--- a/js/gantt-helper.js
+++ b/js/gantt-helper.js
@@ -451,6 +451,11 @@ var GlpiGantt = (function() {
                     'bottom': '18px',
                     'right': '10px'
                 });
+                $('header.navbar').hide();
+                $('aside.navbar').hide();
+                $('#tabspanel').css({
+                    'visibility': 'hidden'
+                });
                 return true;
             });
 
@@ -458,6 +463,11 @@ var GlpiGantt = (function() {
                 $('.gantt-block__features').css({
                     'position': 'initial',
                     'bottom': '10px'
+                });
+                $('header.navbar').show();
+                $('aside.navbar').show();
+                $('#tabspanel').css({
+                    'visibility': 'initial'
                 });
                 return true;
             });


### PR DESCRIPTION
In full screen mode, the GLPI menus remained visible and hid parts of the content.

Before:
![image](https://user-images.githubusercontent.com/8530352/197955498-4f0cbd22-44b3-4c18-80d7-a44bf1e11320.png)

After:
![image](https://user-images.githubusercontent.com/8530352/197955348-183fe249-f18f-4aff-abe3-1e20e3a47bf9.png)
