### PR TITLE
feat: use real dates as priority over planned dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Use real dates as priority over planned dates for tasks and projects

--- a/src/DataFactory.php
+++ b/src/DataFactory.php
@@ -186,8 +186,8 @@ class Datafactory
         $item->type = ($type == "root-project") ? "project" : $type;
         $item->parent = ($type == "root-project") ? 0 : (($type == "project") ? $record['projects_id'] : ($record["projecttasks_id"] > 0 ? $parentTaskUid : $record['projects_id']));
         $item->linktask_id = ($item->type != "project") ? $record["id"] : 0;
-        $item->start_date = $record['plan_start_date'] ?? $_SESSION['glpi_currenttime'];
-        $item->end_date = $record['plan_end_date'] ?? date('Y-m-d H:i:s', strtotime($item->start_date . ' + 1 day'));
+        $item->start_date = $record['real_start_date'] ?? $record['plan_start_date'] ?? $_SESSION['glpi_currenttime'];
+        $item->end_date = $record['real_end_date'] ?? $record['plan_end_date'] ?? date('Y-m-d H:i:s', strtotime($item->start_date . ' + 1 day'));
         $item->text = $record['name'];
         $item->content = isset($record['content']) ? RichText::getSafeHtml($record['content']) : "";
         $item->comment = $record['comment'] ?? "";


### PR DESCRIPTION
Use actual dates in the gantt view when available.
The planned date will be used as the second option if the actual date is not defined.