### PR TITLE
fix: PHP Deprecated function

### DIFF
--- a/ajax/gantt.php
+++ b/ajax/gantt.php
@@ -51,7 +51,9 @@ if (isset($_REQUEST['getData'])) {
     $links = $factory->getProjectTaskLinks($itemArray);
 
     usort($itemArray, function ($a, $b) {
-        return strlen($a->id) <=> strlen($b->id);
+        $lengthA = $a->id !== null ? strlen($a->id) : 0;
+        $lengthB = $b->id !== null ? strlen($b->id) : 0;
+        return $lengthA <=> $lengthB;
     });
 
     $result = [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36471
Prevent this error message:
```
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): strlen(): Passing null to parameter #1 ($string) of type string is deprecated in .../ajax/gantt.php at line 51
  Backtrace :
  :                                                  {closure}()
  marketplace/gantt/ajax/gantt.php:50                usort()
  public/index.php:82                                require()
```


## Screenshots (if appropriate):
