### PR TITLE
Fix: dhtmlx-gantt bump from 8.0 to 9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 node_modules/
 public/build/
+public/lib/
 vendor/
 .gh_token
 *.min.*

--- a/js/libs.js
+++ b/js/libs.js
@@ -26,5 +26,5 @@
  * -------------------------------------------------------------------------
  */
 
-require('dhtmlx-gantt');
-require('dhtmlx-gantt/codebase/dhtmlxgantt.css');
+import 'dhtmlx-gantt/codebase/dhtmlxgantt.js';
+import 'dhtmlx-gantt/codebase/dhtmlxgantt.css';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "dhtmlx-gantt": "^9.0.11"
+        "dhtmlx-gantt": "^9.0.12"
       },
       "devDependencies": {
         "clean-webpack-plugin": "^4.0.0",
@@ -488,10 +488,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -615,10 +616,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -694,9 +696,9 @@
       }
     },
     "node_modules/dhtmlx-gantt": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/dhtmlx-gantt/-/dhtmlx-gantt-9.0.11.tgz",
-      "integrity": "sha512-tbJ4RYud/uSw4MpdBoTxolW7DzCtOnLNzxpFptP0Zqw1yaaNhU7s4Jfq3RnnkmD5WEdFx9bJ+6w6LovegFDHJw==",
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/dhtmlx-gantt/-/dhtmlx-gantt-9.0.12.tgz",
+      "integrity": "sha512-xqBpbh9ZziT24AvwjhFenqHKxgILeZZdgSkOCPZiXggSJlzohD360zyRl1yxH2kiX2OglsXtikIhwjcaEzjx3w==",
       "license": "GPL-2.0"
     },
     "node_modules/electron-to-chromium": {
@@ -1246,9 +1248,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -1256,6 +1258,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2575,9 +2578,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2653,9 +2656,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -2701,9 +2704,9 @@
       }
     },
     "dhtmlx-gantt": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/dhtmlx-gantt/-/dhtmlx-gantt-9.0.11.tgz",
-      "integrity": "sha512-tbJ4RYud/uSw4MpdBoTxolW7DzCtOnLNzxpFptP0Zqw1yaaNhU7s4Jfq3RnnkmD5WEdFx9bJ+6w6LovegFDHJw=="
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/dhtmlx-gantt/-/dhtmlx-gantt-9.0.12.tgz",
+      "integrity": "sha512-xqBpbh9ZziT24AvwjhFenqHKxgILeZZdgSkOCPZiXggSJlzohD360zyRl1yxH2kiX2OglsXtikIhwjcaEzjx3w=="
     },
     "electron-to-chromium": {
       "version": "1.5.50",
@@ -3102,9 +3105,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true
     },
     "neo-async": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-2.0-or-later",
   "dependencies": {
-    "dhtmlx-gantt": "^9.0.11"
+    "dhtmlx-gantt": "^9.0.12"
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/setup.php
+++ b/setup.php
@@ -58,7 +58,7 @@ function plugin_init_gantt()
         'addtabon' => 'Project',
     ]);
 
-    $PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT]['gantt'][] = 'public/build/libs.js';
+    $PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT]['gantt'][] = 'public/lib/libs.js';
     $PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT]['gantt'][] = 'js/gantt-helper.js';
 
     $PLUGIN_HOOKS[Hooks::ADD_CSS]['gantt'][] = 'css/gantt.scss';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = [
       },
       output: {
          filename: 'libs.js',
-         path: path.resolve(__dirname, 'public/build'),
+         path: path.resolve(__dirname, 'public/lib'),
       },
       module: {
          rules: [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes N/A

Since https://github.com/pluginsGLPI/gantt/pull/122, the Gantt chart was no longer displaying.

