### PR TITLE
Fix(dhtmlx-gantt): replace non-free features with free alternatives

### DIFF
--- a/js/gantt-helper.js
+++ b/js/gantt-helper.js
@@ -132,6 +132,10 @@ const GlpiGantt = (function() {
                 if (task.type == "milestone") {
                     css.push("gantt_milestone");
                 }
+                if (task.type == "project") {
+                    css.push("gantt_project");
+                }
+
                 return css.join(" ");
             };
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Since the update of `dhtmlx-gantt` to **v9.0**, the visual distinction between a project (green) and a task (blue) has become a **paid feature** (like `Milestone` -> see https://github.com/pluginsGLPI/gantt/pull/138). 

Many thanks to the dhtmlx-gantt team for this change !  🤮🤮

https://docs.dhtmlx.com/gantt/desktop__task_types.html

This PR restores this functionality **for free**, ensuring that users can still easily differentiate between projects and tasks.

Additionally, the default skin colors (`terrace`) have been refreshed to align with a more **modern UI design**.
https://dhtmlx.com/blog/dhtmlx-gantt-9-0/](https://dhtmlx.com/blog/dhtmlx-gantt-9-0/

<img width="945" height="431" alt="image" src="https://github.com/user-attachments/assets/6c71cbaa-6d53-4431-b1f4-5d7298988195" />



## Screenshots (if appropriate):
