### PR TITLE
fixing the tasks tooltip display for big descriptions and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the task tooltip display in the Gantt view when the comment or the description of the task is too big.
+
 ## [1.1.2] - 2025-09-30
 
 ### Added

--- a/css/gantt.scss
+++ b/css/gantt.scss
@@ -162,6 +162,16 @@
     }
 }
 
+.gantt_tooltip_description {
+    padding-left:25px;
+    max-width:650px;
+    max-height:150px;
+    overflow-x:auto;
+    overflow-y:auto;
+    word-wrap:break-word;
+    white-space:pre-wrap;
+}
+
 #page {
     #gantt-loader-overlay {
         background-color: black;

--- a/js/gantt-helper.js
+++ b/js/gantt-helper.js
@@ -165,10 +165,10 @@ const GlpiGantt = (function() {
                "<br/><b>" + __("End date:", 'gantt') + "</b> " + gantt.templates.tooltip_date_format(end) +
                "<br/><b>" + __("Progress:", 'gantt') + "</b> " + parseInt(task.progress * 100) + "%";
                 if (task.content && task.content.length > 0) {
-                    text += "<br/><b>" + __("Description:", 'gantt') + "</b><div style=\"padding-left:25px; max-width:650px; max-height:150px; overflow-x:auto; overflow-y:auto; word-wrap:break-word; white-space:pre-wrap;\">" + task.content + "</div>";
+                    text += "<br/><b>" + __("Description:", 'gantt') + "</b><div class=\"gantt_tooltip_description\">" + task.content + "</div>";
                 }
                 if (task.comment && task.comment.length > 0) {
-                    text += "<br/><b>" + __("Comment:", 'gantt') + "</b><div style=\"padding-left:25px; max-width:650px; max-height:150px; overflow-x:auto; overflow-y:auto; word-wrap:break-word; white-space:pre-wrap;\">" + task.comment + "</div>";
+                    text += "<br/><b>" + __("Comment:", 'gantt') + "</b><div class=\"gantt_tooltip_description\">" + task.comment + "</div>";
                 }
                 return text;
             };

--- a/js/gantt-helper.js
+++ b/js/gantt-helper.js
@@ -165,10 +165,10 @@ const GlpiGantt = (function() {
                "<br/><b>" + __("End date:", 'gantt') + "</b> " + gantt.templates.tooltip_date_format(end) +
                "<br/><b>" + __("Progress:", 'gantt') + "</b> " + parseInt(task.progress * 100) + "%";
                 if (task.content && task.content.length > 0) {
-                    text += "<br/><b>" + __("Description:", 'gantt') + "</b><div style=\"padding-left:25px\">" + task.content + "</div>";
+                    text += "<br/><b>" + __("Description:", 'gantt') + "</b><div style=\"padding-left:25px; max-width:650px; max-height:150px; overflow-x:auto; overflow-y:auto; word-wrap:break-word; white-space:pre-wrap;\">" + task.content + "</div>";
                 }
                 if (task.comment && task.comment.length > 0) {
-                    text += "<br/><b>" + __("Comment:", 'gantt') + "</b><div style=\"padding-left:25px\">" + task.comment + "</div>";
+                    text += "<br/><b>" + __("Comment:", 'gantt') + "</b><div style=\"padding-left:25px; max-width:650px; max-height:150px; overflow-x:auto; overflow-y:auto; word-wrap:break-word; white-space:pre-wrap;\">" + task.comment + "</div>";
                 }
                 return text;
             };


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes the first problem of ticket 43533.
- The task tooltip wasn't displayed correctly when the description or the comment of the task is too big. 

## Screenshots (if appropriate):

before the fix : 

<img width="3128" height="1093" alt="before" src="https://github.com/user-attachments/assets/e3effd78-1aa4-4175-9e58-216b732e7f7d" />

After the fix : 

<img width="3128" height="1093" alt="after" src="https://github.com/user-attachments/assets/889d57e8-3afd-4455-a9b4-fe78c0a12452" />
