### PR TITLE
Progress automatic calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix the progress percentage of tasks and projects in the Gantt view when it must not be calculated automatically
+- Project progress calculation now includes subtasks, aligning with core GLPI behavior.
 
 ## [1.1.2] - 2025-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the progress percentage of tasks and projects in the Gantt view when it must not be calculated automatically
+
 ## [1.1.2] - 2025-09-30
 
 ### Added

--- a/js/gantt-helper.js
+++ b/js/gantt-helper.js
@@ -575,7 +575,8 @@ const GlpiGantt = (function() {
                 return;
             }
 
-            const children = gantt.getChildren(task.id);
+            const children = getAllChildren(task.id);
+
             let childProgress = 0;
             for (let i = 0; i < children.length; i++) {
                 const child = gantt.getTask(children[i]);
@@ -584,6 +585,20 @@ const GlpiGantt = (function() {
             task.progress = childProgress / children.length / 100;
         }, id);
         gantt.render();
+    }
+
+    /**
+     * Gets all children of a task, including sub-children (recursive)
+     * @param {*} taskId
+     */
+    function getAllChildren(taskId) {
+        const children = [];
+        const directChildren = gantt.getChildren(taskId);
+        for (let i = 0; i < directChildren.length; i++) {
+            children.push(directChildren[i]);
+            children.push(...getAllChildren(directChildren[i]));
+        }
+        return children;
     }
 
     /**

--- a/js/gantt-helper.js
+++ b/js/gantt-helper.js
@@ -126,7 +126,6 @@ const GlpiGantt = (function() {
             gantt.templates.task_class = (start, end, task) =>{
                 const css = [];
                 if (task.type == "project") {
-                    css.push("no_progress_drag");
                     css.push("no_link_drag");
                 }
                 if (task.type == "milestone") {
@@ -134,6 +133,9 @@ const GlpiGantt = (function() {
                 }
                 if (task.type == "project") {
                     css.push("gantt_project");
+                }
+                if(task.auto_percent_done || task.type == "project"){
+                    css.push("no_progress_drag");
                 }
 
                 return css.join(" ");
@@ -569,6 +571,10 @@ const GlpiGantt = (function() {
      */
     function parentProgress(id) {
         gantt.eachParent((task) => {
+            if(!task.auto_percent_done){
+                return;
+            }
+
             const children = gantt.getChildren(task.id);
             let childProgress = 0;
             for (let i = 0; i < children.length; i++) {

--- a/src/DataFactory.php
+++ b/src/DataFactory.php
@@ -195,6 +195,7 @@ class DataFactory
         $item->content     = isset($record['content']) ? RichText::getSafeHtml($record['content']) : '';
         $item->comment     = $record['comment'] ?? '';
         $item->progress    = $record['percent_done'] / 100;
+        $item->auto_percent_done = $record['auto_percent_done'] ?? 0;
 
         return $item;
     }

--- a/src/Item.php
+++ b/src/Item.php
@@ -50,6 +50,9 @@ class Item implements \JsonSerializable
     public $parent;
     public $open; // 1 / 0
 
+    //(to indicate if the progess is automatically calculated based on sub-tasks)
+    public $auto_percent_done;
+
     public function __construct()
     {
         $this->id         = 0;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- Fixes the second issue reported in ticket 43533 and #194 .
- Before this fix, the progress percentage of projects and tasks was always calculated automatically in the plugin view using child tasks, even when this option was not enabled in the GLPI core.
- The plugin now takes this option into account to determine whether progress should be calculated automatically.
- When automatic calculation is enabled, users can no longer manually edit progress by dragging the progress bar in the view, aligning with the GLPI core behavior.
- Automatic progress calculation for tasks and projects now includes subtasks, not only direct tasks, ensuring consistency with the GLPI core.