### PR TITLE
Feat: add Jest regression test for dhtmlx-gantt upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Added a Jest test detecting dhtmlx-gantt upgrades that break the Gantt view.
+
 ## [1.3.3] - 2026-04-22
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,5 @@
+import globals from 'globals';
+
 import glpiEslintConfig from '../../eslint.config.mjs';
 
 const filteredConfig = glpiEslintConfig.filter(config => !config.ignores);
@@ -16,6 +18,13 @@ export default [
         files: ["public/js/libs.js"],
         languageOptions: {
             sourceType: "module"
+        }
+    },
+    {
+        // Node config files
+        files: ["jest.config.js"],
+        languageOptions: {
+            globals: {...globals.node}
         }
     }
 ];

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,33 @@
+/**
+ * -------------------------------------------------------------------------
+ * gantt plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of gantt.
+ *
+ * gantt is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * any later version.
+ *
+ * gantt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gantt. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2013-2023 by gantt plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/gantt
+ * -------------------------------------------------------------------------
+ */
+
+module.exports = {
+    testEnvironment: 'jsdom',
+    testMatch: ['<rootDir>/tests/js/**/*.test.js'],
+    transform: {},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -375,6 +375,15 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -1033,6 +1042,31 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1528,10 +1562,11 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2359,6 +2394,14 @@
       "dev": true,
       "requires": {}
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -2813,6 +2856,17 @@
         "supports-color": "^8.0.0"
       }
     },
+    "js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3124,9 +3178,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
     "raw-loader": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "webpack --config .webpack.config.js",
-    "postinstall": "npm run-script build"
+    "postinstall": "npm run-script build",
+    "test": "jest --colors"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^4.0.0",

--- a/tests/js/gantt-libs.test.js
+++ b/tests/js/gantt-libs.test.js
@@ -1,0 +1,73 @@
+/**
+ * -------------------------------------------------------------------------
+ * gantt plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of gantt.
+ *
+ * gantt is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * any later version.
+ *
+ * gantt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gantt. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2013-2023 by gantt plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/gantt
+ * -------------------------------------------------------------------------
+ */
+
+// Loads the actual webpack bundle (built via the "build"/"postinstall" npm script)
+// the same way the browser does, to catch dhtmlx-gantt upgrades that break the
+// library's own module packaging or drop APIs this plugin relies on.
+describe('dhtmlx-gantt bundle (public/lib/libs.js)', () => {
+    beforeAll(() => {
+        require('../../public/lib/libs.js');
+    });
+
+    test('exposes a usable gantt instance on window', () => {
+        expect(window.gantt).toBeDefined();
+        expect(typeof window.gantt).toBe('object');
+    });
+
+    test('enables the tooltip/fullscreen/undo/marker plugins used by gantt-helper.js', () => {
+        expect(() => {
+            window.gantt.plugins({
+                tooltip: true,
+                fullscreen: true,
+                undo: true,
+                marker: true,
+            });
+        }).not.toThrow();
+
+        expect(typeof window.gantt.addMarker).toBe('function');
+        expect(typeof window.gantt.undo).toBe('function');
+        expect(typeof window.gantt.ext.fullscreen).toBe('object');
+        expect(typeof window.gantt.ext.zoom).toBe('object');
+    });
+
+    test.each([
+        'addTask', 'alert', 'attachEvent', 'calculateTaskLevel', 'changeLinkId',
+        'deleteLink', 'deleteTask', 'eachParent', 'eachTask', 'getChildren',
+        'getLightboxSection', 'getLink', 'getTask', 'hideLightbox', 'init',
+        'message', 'modalbox', 'parse', 'render', 'resetLightbox', 'sort',
+        'updateTask',
+    ])('exposes gantt.%s(), used by gantt-helper.js', (method) => {
+        expect(typeof window.gantt[method]).toBe('function');
+    });
+
+    test('exposes the gantt.date and gantt.i18n helpers used by gantt-helper.js', () => {
+        expect(typeof window.gantt.date.add).toBe('function');
+        expect(typeof window.gantt.date.date_to_str).toBe('function');
+        expect(typeof window.gantt.i18n.setLocale).toBe('function');
+    });
+});


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- Dependabot bumps of dhtmlx-gantt can silently break the Gantt view without showing up in the diff (v10.0.0 turned out to make window.gantt undefined at runtime).
This adds a Jest test loading the actual built bundle (public/lib/libs.js) and asserting the gantt API surface used by gantt-helper.js is present, so the shared plugin CI catches this class of regression automatically.
The plugin relies on GLPI core's own jest/jest-environment-jsdom install (via the CI's `../../node_modules/.bin/jest` fallback), so no new devDependency was added.

## Screenshots (if appropriate):